### PR TITLE
Fix shortcut key jumps to the last item instead of the first one

### DIFF
--- a/jquery.menu.js
+++ b/jquery.menu.js
@@ -44,7 +44,10 @@
 
             // store first char of all menu items
             $allmenuitems.each(function(idx) {
-                shortcutKeyMap[$(this).text()[0]] = idx;
+                var firstChar = $(this).text()[0];
+                if (!shortcutKeyMap[firstChar]) {
+                    shortcutKeyMap[firstChar] = idx;
+                }
             });
 
             // assign id to widget


### PR DESCRIPTION
Bug: if you have 3 items 'Adidas', 'Alba', 'Alpina', pressing 'A' will jump to 'Alpina'
Expected: Pressing 'A' will jump to 'Adidas'.
